### PR TITLE
通过配置文件设定是否允许 bot 收集表情包

### DIFF
--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -5,6 +5,7 @@ bot_config:
   group_handle_logic_operate_level: 1000 #拉黑、解黑群所需操作权限
   邀请bot加群所需权限: 0
   申请bot好友所需权限: 0
+  record_mface: true #是否收集主人的表情包
 api_implements: #花里胡哨
    nudge:               #戳一戳设置。
      counter_probability: 100 #反击概率

--- a/run/system_plugin/Mface_Record.py
+++ b/run/system_plugin/Mface_Record.py
@@ -13,6 +13,10 @@ def main(bot,config):
 
     @bot.on(GroupMessageEvent)
     async def record_mface(event: GroupMessageEvent):
+        # 检查配置中是否允许收集表情包
+        if not config.settings["bot_config"].get("record_mface", False):
+            return
+            
         if event.user_id==config.basic_config["master"]["id"]:
             if event.message_chain.has(Image) and event.message_chain.get(Image)[0].summary!="":
                 summary = event.message_chain.get(Image)[0].summary
@@ -30,6 +34,7 @@ def main(bot,config):
                 await download_img(url,f"data/pictures/Mface/{summary}.{url.split('.')[-1]}")
             except:
                 bot.logger.error(f"下载表情包失败：{summary}，地址：{url}")
+                
     @bot.on(GroupMessageEvent)
     async def send_mface(event: GroupMessageEvent):
         if event.message_chain.has(At) and event.message_chain.get(At)[0].qq==bot.id:


### PR DESCRIPTION
## 变更内容和动机

在 settings.yaml 中新增了 record_mface 一项，可以手动选择是否允许 bot 收集主人的表情包。
主要是因为经常发些比较抽象的表情包，给 bot 用了发感觉有点难绷，所以改了一下，这样就可以只让 bot 发他有的二次元表情包了。

## 检查清单

<!-- 请确保以下步骤均已完成 -->

- [ ] 已在本地经过充分测试
- [ ] 没有同步阻塞代码
- [ ] 适配当前tool的更新机制
- [ ] 【可选】在现有[文档](https://github.com/avilliai/Eridanus_doc) 中提交相关功能的说明

