### PR TITLE
修改使用pro模型时会将思维链输出到聊天中的问题

### DIFF
--- a/run/ai_llm/config.yaml
+++ b/run/ai_llm/config.yaml
@@ -51,6 +51,7 @@ llm:
     base_url: https://generativelanguage.googleapis.com #后面的/v1/beta什么的会自动填充
     temperature: 0.7
     maxOutputTokens: 2048
+    include_thoughts: false  #是否在输出中包含思维链，false则隐藏思考过程只返回正文
     fallback_models:   #code429即到达限额后，会按顺序change_model，直到成功。
       - gemini-2.0-flash
       - gemini-2.5-flash

--- a/run/ai_llm/service/aiReplyCore.py
+++ b/run/ai_llm/service/aiReplyCore.py
@@ -281,6 +281,7 @@ async def aiReplyCore(processed_message, user_id, config, tools=None, bot=None, 
                 temperature=config.ai_llm.config["llm"]["gemini"]["temperature"],
                 maxOutputTokens=config.ai_llm.config["llm"]["gemini"]["maxOutputTokens"],
                 fallback_models=config.ai_llm.config["llm"]["gemini"]["fallback_models"],
+                include_thoughts=config.ai_llm.config["llm"]["gemini"].get("include_thoughts", False),
             )
             logger.info(response_message)
             response_message=response_message['candidates'][0]["content"]

--- a/run/ai_llm/service/aiReplyHandler/gemini.py
+++ b/run/ai_llm/service/aiReplyHandler/gemini.py
@@ -13,7 +13,7 @@ from framework_common.utils.random_str import random_str
 from run.ai_llm.service.aiReplyHandler.ModelFallBackManager import ModelFallbackManager
 
 logger=get_logger("Gemini Prompt Construct and Request")
-async def geminiRequest(ask_prompt,base_url: str,apikey: str,model: str,proxy=None,tools=None,system_instruction=None,temperature=0.7,maxOutputTokens=2048,fallback_models: list[str] = None):
+async def geminiRequest(ask_prompt,base_url: str,apikey: str,model: str,proxy=None,tools=None,system_instruction=None,temperature=0.7,maxOutputTokens=2048,fallback_models: list[str] = None,include_thoughts: bool = False):
     if proxy is not None and proxy !="":
         proxies={"http://": proxy, "https://": proxy}
     else:
@@ -49,7 +49,10 @@ async def geminiRequest(ask_prompt,base_url: str,apikey: str,model: str,proxy=No
                 "topK": 64,
                 "topP": 0.95,
                 "maxOutputTokens": maxOutputTokens,
-                "responseMimeType": "text/plain"
+                "responseMimeType": "text/plain",
+                "thinkingConfig": {
+                    "includeThoughts": include_thoughts
+                }
             }
         }
     else:
@@ -65,7 +68,10 @@ async def geminiRequest(ask_prompt,base_url: str,apikey: str,model: str,proxy=No
                 "topK": 64,
                 "topP": 0.95,
                 "maxOutputTokens": maxOutputTokens,
-                "responseMimeType": "text/plain"
+                "responseMimeType": "text/plain",
+                "thinkingConfig": {
+                    "includeThoughts": include_thoughts
+                }
             }
         }
 


### PR DESCRIPTION
修改使用pro模型时会将思维链输出到聊天中的问题。
因为api返回thoughts和response格式相同，所以会分段发送到聊天中。请求时将include_thoughts设置为false即可不返回thoughts