### PR TITLE
/clear不再清理群印象和上下文，/clearall清，同时增加了/init和/initall来跨群清理，还有管理员可以/clear @某人或者/clear qq号，/init同理

### DIFF
--- a/run/mai_reply/main.py
+++ b/run/mai_reply/main.py
@@ -20,13 +20,14 @@ MaiReply 插件主入口
   - 错字生成
   - 概率触发 + focus持续对话
   - 高并发安全（信号量 + 会话锁 + 消息合并）
-  - /clear 清除对话历史
+  - /clear 清除当前会话，/init 清除指定用户的全局会话
   - 函数调用（兼容 Eridanus func_calling 体系）
 """
 
 import asyncio
 import base64
 import io
+import re
 import uuid
 
 from PIL import Image as PILImage
@@ -164,24 +165,118 @@ def main(bot: ExtendBot, config: YAMLManager):
 
     bot.logger.info("[MaiReply] 高拟人化AI回复插件已加载")
 
+    def is_master(user_id: int) -> bool:
+        master = config.common_config.basic_config["master"]["id"]
+        if isinstance(master, (list, tuple, set)):
+            return str(user_id) in {str(item) for item in master}
+        return str(user_id) == str(master)
+
+    def get_command_text(event) -> str:
+        if getattr(event, "message_chain", None) and event.message_chain.has(Text):
+            return "".join(msg.text for msg in event.message_chain.get(Text)).strip()
+        return (event.pure_text or "").strip()
+
+    def parse_clear_target(event, command: str) -> int | None:
+        if getattr(event, "message_chain", None) and event.message_chain.has(At):
+            target = int(event.message_chain.get(At)[0].qq)
+            if target != 0:
+                return target
+
+        text = get_command_text(event)
+        patterns = [
+            rf"^{re.escape(command)}\s+(\d{{5,12}})\s*$",
+            rf"^{re.escape(command)}(\d{{5,12}})\s*$",
+        ]
+        for pattern in patterns:
+            match = re.match(pattern, text)
+            if match:
+                return int(match.group(1))
+        return None
+
+    def has_at_target(event) -> bool:
+        if not getattr(event, "message_chain", None) or not event.message_chain.has(At):
+            return False
+        return int(event.message_chain.get(At)[0].qq) != 0
+
+    def command_matches(text: str, command: str, has_at_target: bool) -> bool:
+        if text == command or text.startswith(command + " "):
+            return True
+        if not has_at_target or not text.startswith(command):
+            return False
+
+        suffix = text[len(command):]
+        if command == "/clear" and suffix.startswith("all"):
+            return False
+        if command == "/init" and suffix.startswith("all"):
+            return False
+        return True
+
+    async def handle_clear_command(event, is_group: bool) -> bool:
+        text = get_command_text(event)
+        group_id = getattr(event, "group_id", None) if is_group else None
+        has_target_at = has_at_target(event)
+
+        if text in ("/clearall", "清除全部对话", "清理全部对话"):
+            if not is_master(event.user_id):
+                return True
+            count = engine.context.clear_all_sessions(group_id)
+            if is_group:
+                engine.context.clear_all_group_windows(group_id)
+                engine.context.clear_group_impression(group_id)
+                await bot.send(event, f"已清除本群 {count} 个用户的对话记录及群印象～")
+            else:
+                await bot.send(event, f"已清除全部 {count} 个会话记录～")
+            return True
+
+        if text in ("/initall", "初始化全部对话", "重置全部对话"):
+            if not is_master(event.user_id):
+                return True
+            session_count = engine.context.clear_all_sessions()
+            window_count = engine.context.clear_all_group_windows()
+            user_imp_count = engine.context.clear_all_user_impressions()
+            group_imp_count = engine.context.clear_all_group_impressions()
+            await bot.send(
+                event,
+                f"已初始化全部记录：会话 {session_count} 条，群窗口 {window_count} 条，用户印象 {user_imp_count} 条，群印象 {group_imp_count} 条～",
+            )
+            return True
+
+        clear_aliases = ("/clear", "清除对话", "清理对话")
+        init_aliases = ("/init", "初始化对话", "重置对话")
+
+        for command in clear_aliases:
+            if command_matches(text, command, has_target_at):
+                parsed_target_id = parse_clear_target(event, command)
+                target_id = parsed_target_id or event.user_id
+                if target_id != event.user_id and not is_master(event.user_id):
+                    return True
+                engine.context.clear_session(group_id, target_id)
+                engine.context.clear_impression(target_id)
+                if is_group:
+                    await bot.send(event, f"已清除 {target_id} 在本群的对话记录和印象～")
+                else:
+                    await bot.send(event, "好，忘掉了～" if target_id == event.user_id else f"已清除 {target_id} 的私聊记录和印象～")
+                return True
+
+        for command in init_aliases:
+            if command_matches(text, command, has_target_at):
+                parsed_target_id = parse_clear_target(event, command)
+                target_id = parsed_target_id or event.user_id
+                if target_id != event.user_id and not is_master(event.user_id):
+                    return True
+                count = engine.context.clear_user_all_sessions(target_id)
+                engine.context.clear_impression(target_id)
+                await bot.send(event, f"已初始化 {target_id} 在所有群和私聊中的对话记录，共 {count} 条，并清除了用户印象～")
+                return True
+
+        return False
+
     @bot.on(GroupMessageEvent)
     async def handle_group(event: GroupMessageEvent):
         text = event.pure_text or ""
 
         # 清理指令
-        if text.strip() in ("/clear", "清除对话", "清理对话"):
-            engine.context.clear_session(event.group_id, event.user_id)
-            engine.context.clear_impression(event.user_id)
-            if hasattr(event,"group_id"):
-                engine.context.clear_group_impression(event.group_id)
-            await bot.send(event, "好的，对话记录和印象已清除～")
-            return
-        if text.strip() in ("/clearall", "清除全部对话", "清理全部对话"):
-            if event.user_id != config.common_config.basic_config["master"]["id"]:
-                return
-            count = engine.context.clear_all_sessions(event.group_id)
-            engine.context.clear_group_impression(event.group_id)
-            await bot.send(event, f"已清除本群 {count} 个用户的对话记录及群印象～")
+        if await handle_clear_command(event, is_group=True):
             return
 
         async def add_to_context():
@@ -277,16 +372,7 @@ def main(bot: ExtendBot, config: YAMLManager):
     async def handle_private(event: PrivateMessageEvent):
         text = event.pure_text or ""
 
-        if text.strip() in ("/clear", "清除对话", "清理对话"):
-            engine.context.clear_session(None, event.user_id)
-            engine.context.clear_impression(event.user_id)
-            await bot.send(event, "好，忘掉了～")
-            return
-        if text.strip() in ("/clearall", "清除全部对话", "清理全部对话"):
-            if event.user_id != config.common_config.basic_config["master"]["id"]:
-                return
-            count = engine.context.clear_all_sessions()
-            await bot.send(event, f"已清除全部 {count} 个会话记录～")
+        if await handle_clear_command(event, is_group=False):
             return
 
         if not config.mai_reply.config.get("trigger", {}).get("private_trigger", True):

--- a/run/mai_reply/service/context_manager.py
+++ b/run/mai_reply/service/context_manager.py
@@ -62,6 +62,13 @@ class SQLitePersistence:
         self._conn.execute("DELETE FROM kv_store WHERE key = ?", (key,))
         self._conn.commit()
 
+    def keys_like(self, pattern: str) -> List[str]:
+        sql_pattern = pattern.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_").replace("*", "%")
+        rows = self._conn.execute(
+            "SELECT key FROM kv_store WHERE key LIKE ? ESCAPE '\\'", (sql_pattern,)
+        ).fetchall()
+        return [row[0] for row in rows]
+
     def close(self) -> None:
         self._conn.close()
 
@@ -122,6 +129,15 @@ class ContextManager:
         self._ctx_cache.delete(key)
         self._ctx_sqlite.delete(key)
 
+    def _ctx_keys(self, pattern: str) -> List[str]:
+        keys = set()
+        try:
+            keys.update(key.decode("utf-8") if isinstance(key, bytes) else str(key) for key in self._ctx_cache.get_keys(pattern))
+        except Exception:
+            pass
+        keys.update(self._ctx_sqlite.keys_like(pattern))
+        return sorted(keys)
+
     def _ctx_exists(self, key: str) -> bool:
         if self._ctx_cache.exists(key):
             return True
@@ -143,6 +159,15 @@ class ContextManager:
     def _imp_delete(self, key: str) -> None:
         self._imp_cache.delete(key)
         self._imp_sqlite.delete(key)
+
+    def _imp_keys(self, pattern: str) -> List[str]:
+        keys = set()
+        try:
+            keys.update(key.decode("utf-8") if isinstance(key, bytes) else str(key) for key in self._imp_cache.get_keys(pattern))
+        except Exception:
+            pass
+        keys.update(self._imp_sqlite.keys_like(pattern))
+        return sorted(keys)
 
     # ------------------------------------------------------------------ Bot 发送消息 ID 追踪
 
@@ -224,16 +249,47 @@ class ContextManager:
         key = self._group_key(group_id, user_id) if group_id else self._private_key(user_id)
         self._ctx_delete(key)
 
+    def clear_user_all_sessions(self, user_id: int) -> int:
+        patterns = [
+            self._private_key(user_id),
+            f"ctx:group:*:{user_id}",
+        ]
+        keys = set()
+        for pattern in patterns:
+            keys.update(self._ctx_keys(pattern))
+
+        count = 0
+        for key in keys:
+            self._ctx_delete(key)
+            count += 1
+        return count
+
     def clear_all_sessions(self, group_id: Optional[int] = None) -> int:
         if group_id is not None:
-            pattern = f"ctx:group:{group_id}:*"
+            patterns = [f"ctx:group:{group_id}:*"]
         else:
-            pattern = "ctx:*"
-        keys = self._ctx_cache.get_keys(pattern)
+            patterns = ["ctx:private:*", "ctx:group:*"]
+
+        keys = set()
+        for pattern in patterns:
+            keys.update(self._ctx_keys(pattern))
+
         count = 0
         for key in keys:
             if key.startswith("lock:"):
                 continue
+            self._ctx_delete(key)
+            count += 1
+        return count
+
+    def clear_all_group_windows(self, group_id: Optional[int] = None) -> int:
+        patterns = [self._group_window_key(group_id), self._group_recent_speakers_key(group_id)] if group_id is not None else ["ctx:gwin:*", "ctx:speakers:*"]
+        keys = set()
+        for pattern in patterns:
+            keys.update(self._ctx_keys(pattern))
+
+        count = 0
+        for key in keys:
             self._ctx_delete(key)
             count += 1
         return count
@@ -326,6 +382,16 @@ class ContextManager:
         """清除对某个用户的印象记忆（Redis + SQLite 双层同步删除）"""
         self._imp_delete(self._impression_key(user_id))
 
+    def clear_all_user_impressions(self) -> int:
+        keys = self._imp_keys("imp:*")
+        count = 0
+        for key in keys:
+            if key.startswith("imp:group:"):
+                continue
+            self._imp_delete(key)
+            count += 1
+        return count
+
     # ------------------------------------------------------------------ 群聊印象（新增）
 
     def get_group_impression(self, group_id: int) -> str:
@@ -348,6 +414,14 @@ class ContextManager:
     def clear_group_impression(self, group_id: int) -> None:
         """清除某个群的气氛/话题印象（Redis + SQLite 双层同步删除）"""
         self._imp_delete(self._group_impression_key(group_id))
+
+    def clear_all_group_impressions(self) -> int:
+        keys = self._imp_keys("imp:group:*")
+        count = 0
+        for key in keys:
+            self._imp_delete(key)
+            count += 1
+        return count
 
     def get_recent_speaker_impressions(self, group_id: int) -> List[Dict]:
         """


### PR DESCRIPTION
## 变更内容和动机

请在这里简要描述此 PR 中的引入变更，并解释变更的动机。

如为新增功能，请完整列出指令及相关用例。

## 检查清单

<!-- 请确保以下步骤均已完成 -->

- [ ] 已在本地经过充分测试
- [ ] 没有同步阻塞代码
- [ ] 适配当前tool的更新机制
- [ ] 【可选】在现有[文档](https://github.com/AOrbitron/vitepress_eridanus_doc) 中提交相关功能的说明

